### PR TITLE
Types minor fix

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -62,12 +62,12 @@ interface AddressBook {
   getContacts(onProgress?: OnProgressCallback, onFinish?: OnFinishCallback): void;
 }
 
-function getContactsWrapper(): Promise<ContactInformation>;
+function getContactsWrapper(): Promise<ContactInformation[]>;
 function getContactsWrapper(onProgress: OnProgressCallback, onFinish: OnFinishCallback): void;
 function getContactsWrapper(
   onProgress?: OnProgressCallback,
   onFinish?: OnFinishCallback
-): Promise<ContactInformation> | void {
+): Promise<ContactInformation[]> | void {
   if (!onProgress && !onFinish) {
     return new Promise((resolve, reject) => {
       try {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -32,7 +32,7 @@ export interface ContactInformation {
 }
 
 type OnProgressCallback = (progress: number) => void;
-type OnFinishCallback = (contacts: ContactInformation) => void;
+type OnFinishCallback = (contacts: ContactInformation[]) => void;
 
 interface AddressBook {
   /**


### PR DESCRIPTION
`OnFinishCallback` receiving an array of `ContactInformation`, not single item.

```typescript
addressBook.getContacts(
    () => {},
    (contacts) => {
        contacts.forEach(...) // <= typescript compiler throws error here "Property 'forEach' does not exist on type 'ContactInformation'.ts(2339)"
    }
)
```